### PR TITLE
Social media links should open a new page

### DIFF
--- a/src/Contact.js
+++ b/src/Contact.js
@@ -9,7 +9,6 @@ import fb from './assets/images/fb-logo.png'
 import ig from './assets/images/ig-logo.png'
 import tw from './assets/images/tw-logo.png'
 
-
 class Contact extends Component {
   // Set the size of the map here once and it will resize both the container and
   // the child element
@@ -53,13 +52,22 @@ class Contact extends Component {
           <img className="star" src={star} alt={'star'} />
         </div>
         <div className="logos">
-          <a href={'https://www.facebook.com/danscookiejar'}>
+          <a
+            href="https://www.facebook.com/danscookiejar"
+            target="_blank noreferrer noopener"
+          >
             <img className="logo" src={fb} alt={'facebook logo'} />
           </a>
-          <a href={'https://www.instagram.com/danscookiejar/'}>
+          <a
+            href="https://www.instagram.com/danscookiejar/"
+            target="_blank noreferrer noopener"
+          >
             <img className="logo" src={ig} alt={'instagram logo'} />
           </a>
-          <a href={'https://twitter.com/danscookiejar'}>
+          <a
+            href="https://twitter.com/danscookiejar"
+            target="_blank noreferrer noopener"
+          >
             <img className="logo" src={tw} alt={'twitter logo'} />
           </a>
         </div>

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -7,18 +7,18 @@ import './Jumbotron.scss'
 
 const Jumbotron = props =>
   <header id="home" className="jumbotron">
-    <div className="header-left">
-    </div>
+    <div className="header-left" />
     <div className="header-center">
       <img src={logo} className="logo" alt="logo" />
 
       <h1>DAN'S COOKIE JAR</h1>
       <StarDivider />
 
-      <Button width="150px">ORDER NOW</Button>
+      <a href="mailto:danscookiejar@gmail.com">
+        <Button width="150px">ORDER NOW</Button>
+      </a>
     </div>
-    <div className="header-right">
-    </div>
+    <div className="header-right" />
   </header>
 
 export default Jumbotron

--- a/src/themes/_base.scss
+++ b/src/themes/_base.scss
@@ -8,3 +8,11 @@ body {
   font-size: 10px;
   min-width: 1000px;
 }
+
+a,
+a:visited,
+a:link,
+a:active,
+a:hover {
+  color: $c-brown;
+}


### PR DESCRIPTION
Social media links should open a new page instead of using the current window